### PR TITLE
Expanded visibility level to public in order to be able to extend UserInputProcessors

### DIFF
--- a/sshd-shell-spring-boot-starter/src/main/java/sshd/shell/springboot/console/BaseUserInputProcessor.java
+++ b/sshd-shell-spring-boot-starter/src/main/java/sshd/shell/springboot/console/BaseUserInputProcessor.java
@@ -49,7 +49,7 @@ public abstract class BaseUserInputProcessor {
                 : handleUserInputWithMoreTokens(part, userRoles);
     }
     
-    String[] splitAndValidateCommand(String userInput, String regex, int expectedNumberOfParts) throws ShellException {
+    public String[] splitAndValidateCommand(String userInput, String regex, int expectedNumberOfParts) throws ShellException {
         String[] part = userInput.split(regex);
         if (part.length != expectedNumberOfParts) {
             throw new ShellException("Invalid command");

--- a/sshd-shell-spring-boot-starter/src/main/java/sshd/shell/springboot/console/ShellException.java
+++ b/sshd-shell-spring-boot-starter/src/main/java/sshd/shell/springboot/console/ShellException.java
@@ -19,7 +19,7 @@ package sshd.shell.springboot.console;
  *
  * @author anand
  */
-class ShellException extends Exception {
+public class ShellException extends Exception {
     
     private static final long serialVersionUID = 7114130906989289480L;
 

--- a/sshd-shell-spring-boot-starter/src/main/java/sshd/shell/springboot/console/UsageInfo.java
+++ b/sshd-shell-spring-boot-starter/src/main/java/sshd/shell/springboot/console/UsageInfo.java
@@ -15,19 +15,21 @@
  */
 package sshd.shell.springboot.console;
 
+import lombok.AccessLevel;
+
 import java.util.List;
 
 /**
  *
  * @author anand
  */
-@lombok.AllArgsConstructor(access = lombok.AccessLevel.PACKAGE)
+@lombok.AllArgsConstructor(access = AccessLevel.PUBLIC)
 @lombok.Getter
 public class UsageInfo {
 
     private final List<Row> rows;
     
-    @lombok.AllArgsConstructor(access = lombok.AccessLevel.PACKAGE)
+    @lombok.AllArgsConstructor(access = AccessLevel.PUBLIC)
     @lombok.Getter
     public static class Row {
 


### PR DESCRIPTION
I was trying to integrate the project into Spring Boot app (using 2.0.0-M7 version) and wanted to add some more custom input processors.  Everything worked great, except that I was not able to extend the class because a few things were using default protection instead of public.